### PR TITLE
fix: guard against missing _local_setup_util_sh.py in conda prefixes

### DIFF
--- a/recipe/patches/fix_conda_prefix_util_guard.patch
+++ b/recipe/patches/fix_conda_prefix_util_guard.patch
@@ -1,0 +1,22 @@
+--- a/colcon_core/shell/template/prefix.sh.em
++++ b/colcon_core/shell/template/prefix.sh.em
+@@ -109,10 +109,15 @@ _colcon_prefix_sh_source_script() {
+ }
+
+ # get all commands in topological order
+-_colcon_ordered_commands="$(@
+-$_colcon_python_executable "$_colcon_prefix_sh_COLCON_CURRENT_PREFIX/_local_setup_util_sh.py" sh@
++# guard: conda/pixi prefixes are chained as underlays but do not have
++# _local_setup_util_sh.py (it is only generated in colcon workspace installs)
++if [ -f "$_colcon_prefix_sh_COLCON_CURRENT_PREFIX/_local_setup_util_sh.py" ]; then
++_colcon_ordered_commands="$(@
++$_colcon_python_executable "$_colcon_prefix_sh_COLCON_CURRENT_PREFIX/_local_setup_util_sh.py" sh@
+ @[if merge_install]@
+  --merged-install@
+ @[end if]@
+-)"
++)"
++else
++  _colcon_ordered_commands=""
++fi
+ unset _colcon_python_executable

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,6 +9,8 @@ package:
 source:
   url: https://github.com/colcon/${{ name }}/archive/${{ version }}.tar.gz
   sha256: a8f1dd2902d01ba5d9de15f698cb3944c54e1029c0e3c881f85ed3a38afd3602
+  patches:
+    - patches/fix_conda_prefix_util_guard.patch
 
 build:
   number: 0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
     - patches/fix_conda_prefix_util_guard.patch
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install . -vv
   noarch: python
   python:


### PR DESCRIPTION
## Problem

When a colcon workspace chains a conda/pixi prefix as an underlay (e.g. in a
RoboStack + Pixi setup), `local_setup.sh` tries to invoke
`_local_setup_util_sh.py` from that prefix. The file only exists in colcon
workspace installs, not in conda prefixes, causing `install/setup.bash` to
silently fail on macOS (osx-arm64) with Pixi-based ROS environments.

Reported in:
- https://github.com/colcon/colcon-core/issues/734
- https://github.com/RoboStack/ros-humble/issues/409

Suggested by @Tobias-Fischer in the RoboStack issue.

## Fix

Add a guard in `prefix.sh.em` to skip the Python invocation when
`_local_setup_util_sh.py` is absent in the current prefix, allowing the
chained sourcing to complete correctly.